### PR TITLE
chore: added symlink for /etc/containers/systemd/*.container & /usr/lib/bootc/bound-images.d/*

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,7 @@ set -ouex pipefail
 mkdir -m 0700 -p /var/roothome
 # Fast track https://gitlab.com/fedora/bootc/base-images/-/merge_requests/71
 ln -sf /run /var/run
-
+# Required for Logically Bound images, see https://gitlab.com/fedora/bootc/examples/-/tree/main/logically-bound-images/usr/share/containers/systemd
+ln -sr /etc/containers/systemd/*.container /usr/lib/bootc/bound-images.d/
 
 systemctl enable podman.socket


### PR DESCRIPTION
Added a symlink from all container unit files to sync with /usr/lib/bootc/bound-images.d/ * to be managed as a Logically Bound Image with the guidance from Fedora Bootc examples. (https://gitlab.com/fedora/bootc/examples/-/tree/main/logically-bound-images/usr/share/containers/systemd).

Please note, this assumes all containers will be treated as logically bounded. 