### PR TITLE
feat: add firewalld, use docker for portainer

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,11 @@ ln -sr /etc/containers/systemd/*.container /usr/lib/bootc/bound-images.d/
 
 # Packages
 
-dnf install -y cockpit cockpit-machines cockpit-podman cockpit-files libvirt tmux vim
+dnf install -y cockpit cockpit-machines cockpit-podman cockpit-files libvirt tmux vim firewalld
+
+# Docker install: https://docs.docker.com/engine/install/centos/#install-using-the-repository
+dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+dnf install -y docker-ce docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 # Tailscale
 dnf config-manager --add-repo https://pkgs.tailscale.com/stable/centos/9/tailscale.repo
@@ -26,3 +30,4 @@ systemctl enable cockpit.socket
 systemctl enable rpm-ostreed-automatic.timer 
 systemctl enable tailscaled.service
 systemctl disable auditd.service
+systemctl enable docker.service

--- a/etc/containers/systemd/portainer.container
+++ b/etc/containers/systemd/portainer.container
@@ -3,6 +3,7 @@ Description=Portainer Container
 After=local-fs.target 
 Wants=network-online.target 
 After=network-online.target
+After=docker.service
 
 [Container]
 Image=docker.io/portainer/portainer-ce:alpine-sts
@@ -13,7 +14,7 @@ LogDriver=journald
 
 PublishPort=9443:9443
 PublishPort=9000:9000
-Volume=/run/podman/podman.sock:/var/run/docker.sock:z
+Volume=/var/run/docker.sock:/var/run/docker.sock:z
 Volume=portainer.volume:/data
 Volume=/:/host
 PodmanArgs=--privileged


### PR DESCRIPTION
This PR adds firewalld for firewall (can be accessed from cockpit), and uses docker rather than podman for portainer, to hopefully make everything autostart on boot (podman is daemonless and usually expects users to make their services with pods and quadlets for startup on boot.) 