### PR TITLE
[feat] add qemu-guest-agent

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ ln -sr /etc/containers/systemd/*.container /usr/lib/bootc/bound-images.d/
 
 # Packages
 
-dnf install -y avahi cockpit cockpit-machines cockpit-podman cockpit-files libvirt tmux vim firewalld
+dnf install -y avahi cockpit cockpit-machines cockpit-podman cockpit-files libvirt tmux vim firewalld qemu-guest-agent
 
 # Docker install: https://docs.docker.com/engine/install/centos/#install-using-the-repository
 dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo


### PR DESCRIPTION
This change adds the "qemu-guest-agent" package, which allows communication between a VM guest (running this image) and a hypervisor host (running a qemu-based hypervisor, such as Proxmox or libvirt).

I've never heard of any adverse effects having that installed/running on an unsupported platform -- it just won't do anything. So I figure it's worth it for the quality-of-life improvement for users that may run this on a VM.